### PR TITLE
fix [#5]: switches to line based diff for special files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/linux-immutability-tools/EtcBuilder
 go 1.20
 
 require (
-	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.7.0
 )
 


### PR DESCRIPTION
Merging files like /etc/shadow is only reliably possible with a line-based diff. 

As far as I can see, github.com/sergi/go-diff/diffmatchpatch doesn't provide a way to compute a line-based diff.

Because a line-based diff is something rather basic, it's probably best to not rely on a library for that. Thus, I implemented it inside EtcBuilder. 

Fixes #5 