### PR TITLE
adds support for device files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,6 @@ func main() {
 }
 ```
 
+### Build Flags
+
+The nodevfiles build tag removes support for device files.

--- a/cmd/deviceFileHandler.go
+++ b/cmd/deviceFileHandler.go
@@ -1,0 +1,41 @@
+//go:build !nodevfiles
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func init() {
+	ExternalFileHandlers = append(ExternalFileHandlers, FileHandler{checkIfDeviceFile, copyDeviceFile})
+}
+
+func checkIfDeviceFile(filePath string) bool {
+	info, err := os.Lstat(filePath)
+	if err != nil {
+		return false
+	}
+	if strings.HasPrefix(info.Mode().Type().String(), "D") {
+		return true
+	}
+	return false
+}
+
+func copyDeviceFile(relFromPath, oldSysDir, newSysDir, oldUserDir, newUserDir string) error {
+	fmt.Println("Keeping user device file", relFromPath)
+
+	fromPath := filepath.Join(oldUserDir, relFromPath)
+	toPath := filepath.Join(newUserDir, relFromPath)
+
+	var stat syscall.Stat_t
+	err := syscall.Lstat(fromPath, &stat)
+	if err != nil {
+		return err
+	}
+	err = syscall.Mknod(toPath, stat.Mode, int(stat.Rdev))
+	return err
+}


### PR DESCRIPTION
Fixes #17 

This is a draft because it depends on #14 

This uses build flags because not every user of EtcBuilder might require support for device files.
For the reason why I used `//go:build flag` instead of `// +build flag` see https://tip.golang.org/doc/go1.18#go-build-lines

It is also built in a way that allows for Library users to provide their own file handlers. 